### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ $ cd ~/ros2_ws/src
 $ git clone https://github.com/rt-net/raspimouse2
 
 # Install dependencies
-$ rosdep install -r -y --from-paths . --ignore-src
+$ rosdep install -r -y -i --from-paths .
 
 # Build & Install
 $ cd ~/ros2_ws


### PR DESCRIPTION
<!-- プルリクエストのタイトルと以下の記述項目は、日本語で書いても良いです -->

# Checklists
<!-- PR作成時にチェックボックスにチェックを入れてください -->

- [x] <!-- コントリビューティングガイドラインを読みました--> I have read the CONTRIBUTING document.
- [x] <!-- 同じ変更を要求するオープンなPRが無いことを確認しました --> I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same change.

# What does this implement/fix? Explain your changes.
<!-- このPRはどんな機能改善/修正ですか？ -->

`rosdep`の`--ignore-src`は`-i`で省略できるのでREADMEに記載する内容を更新しています。

<details>
<summary>rosdep --helpの結果</summary>

```
$ rosdep --version
0.19.0

$ rosdep --help
Usage: rosdep [options] <command> <args>

Commands:

rosdep check <stacks-and-packages>...
  check if the dependencies of package(s) have been met.

rosdep install <stacks-and-packages>...
  download and install the dependencies of a given package or packages.

rosdep db
  generate the dependency database and print it to the console.

rosdep init
  initialize rosdep sources in /etc/ros/rosdep.  May require sudo.

rosdep keys <stacks-and-packages>...
  list the rosdep keys that the packages depend on.

rosdep resolve <rosdeps>
  resolve <rosdeps> to system dependencies

rosdep update
  update the local rosdep database based on the rosdep sources.

rosdep what-needs <rosdeps>...
  print a list of packages that declare a rosdep on (at least
  one of) <rosdeps>

rosdep where-defined <rosdeps>...
  print a list of yaml files that declare a rosdep on (at least
  one of) <rosdeps>

rosdep fix-permissions
  Recursively change the permissions of the user's ros home directory.
  May require sudo.  Can be useful to fix permissions after calling
  "rosdep update" with sudo accidentally.


Options:
  -h, --help            show this help message and exit
  --os=OS_NAME:OS_VERSION
                        Override OS name and version (colon-separated), e.g.
                        ubuntu:lucid
  -c SOURCES_CACHE_DIR, --sources-cache-dir=SOURCES_CACHE_DIR
                        Override /home/daisuke/.ros/rosdep/sources.cache
  -v, --verbose         verbose display
  --version             print just the rosdep version, then exit
  --all-versions        print rosdep version and version of installers, then
                        exit
  --reinstall           (re)install all dependencies, even if already
                        installed
  -y, --default-yes     Tell the package manager to default to y or fail when
                        installing
  -s, --simulate        Simulate install
  -r                    Continue installing despite errors.
  -q                    Quiet. Suppress output except for errors.
  -a, --all             select all packages
  -n                    Do not consider implicit/recursive dependencies.  Only
                        valid with 'keys', 'check', and 'install' commands.
  -i, --ignore-packages-from-source, --ignore-src
                        Affects the 'check', 'install', and 'keys' verbs. If
                        specified then rosdep will ignore keys that are found
                        to be catkin or ament packages anywhere in the
                        ROS_PACKAGE_PATH, AMENT_PREFIX_PATH or in any of the
                        directories given by the --from-paths option.
  --skip-keys=SKIP_KEYS
                        Affects the 'check' and 'install' verbs. The specified
                        rosdep keys will be ignored, i.e. not resolved and not
                        installed. The option can be supplied multiple times.
                        A space separated list of rosdep keys can also be
                        passed as a string. A more permanent solution to
                        locally ignore a rosdep key is creating a local rosdep
                        rule with an empty list of packages (include it in
                        /etc/ros/rosdep/sources.list.d/ before the defaults).
  --filter-for-installers=FILTER_FOR_INSTALLERS
                        Affects the 'db' verb. If supplied, the output of the
                        'db' command is filtered to only list packages whose
                        installer is in the provided list. The option can be
                        supplied multiple times. A space separated list of
                        installers can also be passed as a string. Example:
                        `--filter-for-installers "apt pip"`
  --from-paths          Affects the 'check', 'keys', and 'install' verbs. If
                        specified the arguments to those verbs will be
                        considered paths to be searched, acting on all catkin
                        packages found there in.
  --rosdistro=ROS_DISTRO
                        Explicitly sets the ROS distro to use, overriding the
                        normal method of detecting the ROS distro using the
                        ROS_DISTRO environment variable. When used with the
                        'update' verb, only the specified distro will be
                        updated.
  --as-root=INSTALLER_KEY:<bool>
                        Override whether sudo is used for a specific
                        installer, e.g. '--as-root pip:false' or '--as-root
                        "pip:no homebrew:yes"'. Can be specified multiple
                        times.
  --include-eol-distros
                        Affects the 'update' verb. If specified end-of-life
                        distros are being fetched too.

```
</details>

# Does this close any currently open issues?
<!-- このPRはオープンになっているissueをクローズしますか？ -->
しません。

# How has this been tested?
<!-- このPRはどのようにテストしましたか？ -->

このROSパッケージでは直接影響を受けません。