### PR TITLE
パラメータの追加 （#34）

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,33 @@ Similarly other sensor information can also be viewed by echoing the relevant to
   Use hardware pulse counters as the odometry source. When set to true, hardware pulse counters
   will be used only if present.
 
+- `wheel_diameter`
+
+  Type: `double`
+
+  Default: `0.048`
+
+  Sets the diameter of the robot's wheel.
+  The unit is in meters.
+  
+- `wheel_tread`
+
+  Type: `double`
+
+  Default: `0.0925`
+
+  Sets the distance between the wheels.
+  The unit is in meters.
+
+- `pulses_per_revolution`
+
+  Type: `double`
+
+  Default: `400.0`
+
+  Sets the number of pulses needed for 1 rotation of the used motor.
+
+
 ## License
 
 This repository is licensed under the Apache 2.0, see [LICENSE](./LICENSE) for details.

--- a/raspimouse/src/raspimouse_component.cpp
+++ b/raspimouse/src/raspimouse_component.cpp
@@ -33,9 +33,9 @@ constexpr auto use_light_sensors_param = "use_light_sensors";
 constexpr auto odometry_scale_left_wheel_param = "odometry_scale_left_wheel";
 constexpr auto odometry_scale_right_wheel_param = "odometry_scale_right_wheel";
 
-constexpr auto wheel_diameter_param = "wheel_diameter";
-constexpr auto wheel_base_param = "wheel_base";
-constexpr auto PULSES_PER_REVOLUTION_PARAM= "PULSES_PER_REVOLUTION";
+constexpr auto WHEEL_DIAMETER_PARAM = "wheel_diameter";
+constexpr auto WHEEL_BASE_PARAM = "wheel_base";
+constexpr auto PULSES_PER_REVOLUTION_PARAM= "pulses_per_revolution";
 
 constexpr auto DEVFILE_COUNTER_L = "/dev/rtcounter_l1";
 constexpr auto DEVFILE_COUNTER_R = "/dev/rtcounter_r1";

--- a/raspimouse/src/raspimouse_component.cpp
+++ b/raspimouse/src/raspimouse_component.cpp
@@ -186,7 +186,7 @@ CallbackReturn Raspimouse::on_configure(const rclcpp_lifecycle::State &)
   declare_parameter(odometry_scale_left_wheel_param, 1.0);
   declare_parameter(odometry_scale_right_wheel_param, 1.0);
   declare_parameter(WHEEL_DIAMETER_PARAM, 0.048);
-  declare_parameter(WHEEL_BASE_PARAM, 0.09);
+  declare_parameter(WHEEL_BASE_PARAM, 0.0925);
   declare_parameter(PULSES_PER_REVOLUTION_PARAM, 400.0);
 
   // Test if the pulse counters are available

--- a/raspimouse/src/raspimouse_component.cpp
+++ b/raspimouse/src/raspimouse_component.cpp
@@ -487,8 +487,8 @@ void Raspimouse::stop_motors()
 
 void Raspimouse::calculate_odometry_from_pulse_counts(double & x, double & y, double & theta)
 {
-  double WHEEL_DIAMETER = get_parameter(WHEEL_DIAMETER_PARAM).get_value<double>();
-  double WHEEL_TREAD = get_parameter(WHEEL_TREAD_PARAM).get_value<double>();
+  const auto WHEEL_DIAMETER = get_parameter(WHEEL_DIAMETER_PARAM).get_value<double>();
+  const auto WHEEL_TREAD = get_parameter(WHEEL_TREAD_PARAM).get_value<double>();
   const auto PULSES_PER_REVOLUTION = get_parameter(PULSES_PER_REVOLUTION_PARAM).get_value<double>();
 
   auto one_revolution_distance_left = M_PI * WHEEL_DIAMETER *

--- a/raspimouse/src/raspimouse_component.cpp
+++ b/raspimouse/src/raspimouse_component.cpp
@@ -489,7 +489,7 @@ void Raspimouse::calculate_odometry_from_pulse_counts(double & x, double & y, do
 {
   double wheel_diameter = get_parameter(WHEEL_DIAMETER_PARAM).get_value<double>();
   double wheel_base = get_parameter(WHEEL_BASE_PARAM).get_value<double>();
-  auto PULSES_PER_REVOLUTION = get_parameter(PULSES_PER_REVOLUTION_PARAM).get_value<double>();
+  const auto PULSES_PER_REVOLUTION = get_parameter(PULSES_PER_REVOLUTION_PARAM).get_value<double>();
 
   auto one_revolution_distance_left = M_PI * wheel_diameter *
     get_parameter(odometry_scale_left_wheel_param).get_value<double>();

--- a/raspimouse/src/raspimouse_component.cpp
+++ b/raspimouse/src/raspimouse_component.cpp
@@ -34,7 +34,7 @@ constexpr auto odometry_scale_left_wheel_param = "odometry_scale_left_wheel";
 constexpr auto odometry_scale_right_wheel_param = "odometry_scale_right_wheel";
 
 constexpr auto WHEEL_DIAMETER_PARAM = "wheel_diameter";
-constexpr auto WHEEL_BASE_PARAM = "wheel_base";
+constexpr auto WHEEL_TREAD_PARAM = "wheel_tread";
 constexpr auto PULSES_PER_REVOLUTION_PARAM= "pulses_per_revolution";
 
 constexpr auto DEVFILE_COUNTER_L = "/dev/rtcounter_l1";
@@ -186,7 +186,7 @@ CallbackReturn Raspimouse::on_configure(const rclcpp_lifecycle::State &)
   declare_parameter(odometry_scale_left_wheel_param, 1.0);
   declare_parameter(odometry_scale_right_wheel_param, 1.0);
   declare_parameter(WHEEL_DIAMETER_PARAM, 0.048);
-  declare_parameter(WHEEL_BASE_PARAM, 0.0925);
+  declare_parameter(WHEEL_TREAD_PARAM, 0.0925);
   declare_parameter(PULSES_PER_REVOLUTION_PARAM, 400.0);
 
   // Test if the pulse counters are available
@@ -488,7 +488,7 @@ void Raspimouse::stop_motors()
 void Raspimouse::calculate_odometry_from_pulse_counts(double & x, double & y, double & theta)
 {
   double wheel_diameter = get_parameter(WHEEL_DIAMETER_PARAM).get_value<double>();
-  double wheel_base = get_parameter(WHEEL_BASE_PARAM).get_value<double>();
+  double wheel_tread = get_parameter(WHEEL_TREAD_PARAM).get_value<double>();
   const auto PULSES_PER_REVOLUTION = get_parameter(PULSES_PER_REVOLUTION_PARAM).get_value<double>();
 
   auto one_revolution_distance_left = M_PI * wheel_diameter *
@@ -537,7 +537,7 @@ void Raspimouse::calculate_odometry_from_pulse_counts(double & x, double & y, do
     get_logger(), "Left dist: %f\tRight dist: %f\tAverage: %f",
     left_distance, right_distance, average_distance);
 
-  theta += atan2(right_distance - left_distance, wheel_base);
+  theta += atan2(right_distance - left_distance, wheel_tread);
   x += average_distance * cos(theta);
   y += average_distance * sin(theta);
 

--- a/raspimouse/src/raspimouse_component.cpp
+++ b/raspimouse/src/raspimouse_component.cpp
@@ -33,9 +33,6 @@ constexpr auto use_light_sensors_param = "use_light_sensors";
 constexpr auto odometry_scale_left_wheel_param = "odometry_scale_left_wheel";
 constexpr auto odometry_scale_right_wheel_param = "odometry_scale_right_wheel";
 
-// constexpr auto wheel_diameter = 0.048;
-// constexpr auto wheel_base = 0.09;
-// constexpr auto PULSES_PER_REVOLUTION = 400.0;
 constexpr auto wheel_diameter_param = "wheel_diameter";
 constexpr auto wheel_base_param = "wheel_base";
 constexpr auto PULSES_PER_REVOLUTION_PARAM= "PULSES_PER_REVOLUTION";

--- a/raspimouse/src/raspimouse_component.cpp
+++ b/raspimouse/src/raspimouse_component.cpp
@@ -487,13 +487,13 @@ void Raspimouse::stop_motors()
 
 void Raspimouse::calculate_odometry_from_pulse_counts(double & x, double & y, double & theta)
 {
-  double wheel_diameter = get_parameter(WHEEL_DIAMETER_PARAM).get_value<double>();
-  double wheel_tread = get_parameter(WHEEL_TREAD_PARAM).get_value<double>();
+  double WHEEL_DIAMETER = get_parameter(WHEEL_DIAMETER_PARAM).get_value<double>();
+  double WHEEL_TREAD = get_parameter(WHEEL_TREAD_PARAM).get_value<double>();
   const auto PULSES_PER_REVOLUTION = get_parameter(PULSES_PER_REVOLUTION_PARAM).get_value<double>();
 
-  auto one_revolution_distance_left = M_PI * wheel_diameter *
+  auto one_revolution_distance_left = M_PI * WHEEL_DIAMETER *
     get_parameter(odometry_scale_left_wheel_param).get_value<double>();
-  auto one_revolution_distance_right = M_PI * wheel_diameter *
+  auto one_revolution_distance_right = M_PI * WHEEL_DIAMETER *
     get_parameter(odometry_scale_right_wheel_param).get_value<double>();
 
   RCLCPP_DEBUG(get_logger(), "Reading counters");
@@ -537,7 +537,7 @@ void Raspimouse::calculate_odometry_from_pulse_counts(double & x, double & y, do
     get_logger(), "Left dist: %f\tRight dist: %f\tAverage: %f",
     left_distance, right_distance, average_distance);
 
-  theta += atan2(right_distance - left_distance, wheel_tread);
+  theta += atan2(right_distance - left_distance, WHEEL_TREAD);
   x += average_distance * cos(theta);
   y += average_distance * sin(theta);
 

--- a/raspimouse/src/raspimouse_component.cpp
+++ b/raspimouse/src/raspimouse_component.cpp
@@ -185,9 +185,9 @@ CallbackReturn Raspimouse::on_configure(const rclcpp_lifecycle::State &)
   declare_parameter(use_light_sensors_param, true);
   declare_parameter(odometry_scale_left_wheel_param, 1.0);
   declare_parameter(odometry_scale_right_wheel_param, 1.0);
-  declare_parameter(WHEEL_DIAMETER_PARAM, 1.0);
-  declare_parameter(WHEEL_BASE_PARAM, 1.0);
-  declare_parameter(PULSES_PER_REVOLUTION_PARAM, 1.0);
+  declare_parameter(WHEEL_DIAMETER_PARAM, 0.048);
+  declare_parameter(WHEEL_BASE_PARAM, 0.09);
+  declare_parameter(PULSES_PER_REVOLUTION_PARAM, 400.0);
 
   // Test if the pulse counters are available
   if (get_parameter(use_pulse_counters_param).get_value<bool>()) {

--- a/raspimouse/src/raspimouse_component.cpp
+++ b/raspimouse/src/raspimouse_component.cpp
@@ -33,8 +33,10 @@ constexpr auto use_light_sensors_param = "use_light_sensors";
 constexpr auto odometry_scale_left_wheel_param = "odometry_scale_left_wheel";
 constexpr auto odometry_scale_right_wheel_param = "odometry_scale_right_wheel";
 
-constexpr auto wheel_diameter = 0.048;
-constexpr auto wheel_base = 0.09;
+// constexpr auto wheel_diameter = 0.048;
+// constexpr auto wheel_base = 0.09;
+constexpr auto wheel_diameter_param = "wheel_diameter";
+constexpr auto wheel_base_param = "wheel_base";
 constexpr auto PULSES_PER_REVOLUTION = 400.0;
 
 constexpr auto DEVFILE_COUNTER_L = "/dev/rtcounter_l1";
@@ -185,6 +187,8 @@ CallbackReturn Raspimouse::on_configure(const rclcpp_lifecycle::State &)
   declare_parameter(use_light_sensors_param, true);
   declare_parameter(odometry_scale_left_wheel_param, 1.0);
   declare_parameter(odometry_scale_right_wheel_param, 1.0);
+  declare_parameter(wheel_base_param, 1.0);
+  declare_parameter(wheel_diameter_param, 1.0);
 
   // Test if the pulse counters are available
   if (get_parameter(use_pulse_counters_param).get_value<bool>()) {
@@ -484,6 +488,9 @@ void Raspimouse::stop_motors()
 
 void Raspimouse::calculate_odometry_from_pulse_counts(double & x, double & y, double & theta)
 {
+  double wheel_diameter = get_parameter(wheel_diameter_param).get_value<double>();
+  double wheel_base = get_parameter(wheel_base_param).get_value<double>();
+
   auto one_revolution_distance_left = M_PI * wheel_diameter *
     get_parameter(odometry_scale_left_wheel_param).get_value<double>();
   auto one_revolution_distance_right = M_PI * wheel_diameter *

--- a/raspimouse/src/raspimouse_component.cpp
+++ b/raspimouse/src/raspimouse_component.cpp
@@ -35,9 +35,10 @@ constexpr auto odometry_scale_right_wheel_param = "odometry_scale_right_wheel";
 
 // constexpr auto wheel_diameter = 0.048;
 // constexpr auto wheel_base = 0.09;
+// constexpr auto PULSES_PER_REVOLUTION = 400.0;
 constexpr auto wheel_diameter_param = "wheel_diameter";
 constexpr auto wheel_base_param = "wheel_base";
-constexpr auto PULSES_PER_REVOLUTION = 400.0;
+constexpr auto PULSES_PER_REVOLUTION_PARAM= "PULSES_PER_REVOLUTION";
 
 constexpr auto DEVFILE_COUNTER_L = "/dev/rtcounter_l1";
 constexpr auto DEVFILE_COUNTER_R = "/dev/rtcounter_r1";
@@ -187,8 +188,9 @@ CallbackReturn Raspimouse::on_configure(const rclcpp_lifecycle::State &)
   declare_parameter(use_light_sensors_param, true);
   declare_parameter(odometry_scale_left_wheel_param, 1.0);
   declare_parameter(odometry_scale_right_wheel_param, 1.0);
-  declare_parameter(wheel_base_param, 1.0);
   declare_parameter(wheel_diameter_param, 1.0);
+  declare_parameter(wheel_base_param, 1.0);
+  declare_parameter(PULSES_PER_REVOLUTION_PARAM, 1.0);
 
   // Test if the pulse counters are available
   if (get_parameter(use_pulse_counters_param).get_value<bool>()) {
@@ -490,6 +492,7 @@ void Raspimouse::calculate_odometry_from_pulse_counts(double & x, double & y, do
 {
   double wheel_diameter = get_parameter(wheel_diameter_param).get_value<double>();
   double wheel_base = get_parameter(wheel_base_param).get_value<double>();
+  auto PULSES_PER_REVOLUTION = get_parameter(PULSES_PER_REVOLUTION_PARAM).get_value<double>();
 
   auto one_revolution_distance_left = M_PI * wheel_diameter *
     get_parameter(odometry_scale_left_wheel_param).get_value<double>();
@@ -514,7 +517,7 @@ void Raspimouse::calculate_odometry_from_pulse_counts(double & x, double & y, do
   last_odom_time_ = now();
 
   // Detect overflow/underflow
-  constexpr auto OVERFLOW_THRESHOLD = 2.0 * PULSES_PER_REVOLUTION;
+  const auto OVERFLOW_THRESHOLD = 2.0 * PULSES_PER_REVOLUTION;
   if (fabs(pulse_count_difference_left) > OVERFLOW_THRESHOLD ||
     fabs(pulse_count_difference_right) > OVERFLOW_THRESHOLD)
   {

--- a/raspimouse/src/raspimouse_component.cpp
+++ b/raspimouse/src/raspimouse_component.cpp
@@ -185,8 +185,8 @@ CallbackReturn Raspimouse::on_configure(const rclcpp_lifecycle::State &)
   declare_parameter(use_light_sensors_param, true);
   declare_parameter(odometry_scale_left_wheel_param, 1.0);
   declare_parameter(odometry_scale_right_wheel_param, 1.0);
-  declare_parameter(wheel_diameter_param, 1.0);
-  declare_parameter(wheel_base_param, 1.0);
+  declare_parameter(WHEEL_DIAMETER_PARAM, 1.0);
+  declare_parameter(WHEEL_BASE_PARAM, 1.0);
   declare_parameter(PULSES_PER_REVOLUTION_PARAM, 1.0);
 
   // Test if the pulse counters are available

--- a/raspimouse/src/raspimouse_component.cpp
+++ b/raspimouse/src/raspimouse_component.cpp
@@ -487,8 +487,8 @@ void Raspimouse::stop_motors()
 
 void Raspimouse::calculate_odometry_from_pulse_counts(double & x, double & y, double & theta)
 {
-  double wheel_diameter = get_parameter(wheel_diameter_param).get_value<double>();
-  double wheel_base = get_parameter(wheel_base_param).get_value<double>();
+  double wheel_diameter = get_parameter(WHEEL_DIAMETER_PARAM).get_value<double>();
+  double wheel_base = get_parameter(WHEEL_BASE_PARAM).get_value<double>();
   auto PULSES_PER_REVOLUTION = get_parameter(PULSES_PER_REVOLUTION_PARAM).get_value<double>();
 
   auto one_revolution_distance_left = M_PI * wheel_diameter *


### PR DESCRIPTION
<!-- プルリクエストのタイトルと以下の記述項目は、日本語で書いても良いです -->

# What does this implement/fix?
<!-- Explain your changes here. -->
<!-- このPRはどんな機能改善/修正ですか？ -->


# Does this close any currently open issues?
<!-- このPRはオープンになっているissueをクローズしますか？ -->
#34 の対応です。
wheel_diameter, wheel_base, PULSES_PER_REVOLUTIONの3つをROSパラメータ化しました。

# How has this been tested?
<!-- このPRはどのようにテストしましたか？ -->
手元のロボットで動作確認を行いました。  
```sh
$ ros2 launch raspimouse_ros2_examples teleop_joy.launch.py joyconfig:=f710
```
このとき、ロボット側の`raspimouse_ros2_examples`にあるconfig/mouse.ymlファイルに以下の3行を追加して実行しました。  
```yaml
    wheel_diameter : 0.048
    wheel_base : 0.09
    PULSES_PER_REVOLUTION : 400.0
```

パラメータの確認方法として、以下のコマンドを実行しました。  
```sh
$ ros2 param get /raspimouse wheel_base 
Double value is: 0.09
```

# Any other comments?
<!-- その他コメントはありますか？ -->


# Checklists
<!-- PR作成時にチェックボックスにチェックを入れてください -->

- [x] <!-- コントリビューティングガイドラインを読みました--> I have read the CONTRIBUTING guidelines.
- [x] <!-- 同じ変更を要求するオープンなPRが無いことを確認しました --> I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same change.
