### PR TITLE
Add initial_motor_power param

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,7 +250,15 @@ Similarly other sensor information can also be viewed by echoing the relevant to
   Sets the frequency of the publishing rate of the topic /light_sensors.
   The unit is in Hz.
 
+- `initial_motor_power`
 
+  Type: `bool`
+
+  Default: `False`
+
+  Sets the initial state of the motor.
+  If set as `True`, the motors will turn on when the `raspimouse` node becomes active.
+  
 ## License
 
 This repository is licensed under the Apache 2.0, see [LICENSE](./LICENSE) for details.

--- a/raspimouse/src/raspimouse_component.cpp
+++ b/raspimouse/src/raspimouse_component.cpp
@@ -233,7 +233,8 @@ CallbackReturn Raspimouse::on_activate(const rclcpp_lifecycle::State &)
   }
 
   // Set the motor on/off
-  set_motor_power(INIT_MOTOR_POWER_PARAM);
+  const auto INIT_MOTOR_POWER = get_parameter(INIT_MOTOR_POWER_PARAM).get_value<bool>();
+  set_motor_power(INIT_MOTOR_POWER);
 
   RCLCPP_INFO(this->get_logger(), "Raspimouse node activated");
   return CallbackReturn::SUCCESS;

--- a/raspimouse/src/raspimouse_component.cpp
+++ b/raspimouse/src/raspimouse_component.cpp
@@ -38,7 +38,7 @@ constexpr auto LIGHT_SENSORS_HZ_PARAM = "light_sensors_hz";
 constexpr auto WHEEL_DIAMETER_PARAM = "wheel_diameter";
 constexpr auto WHEEL_TREAD_PARAM = "wheel_tread";
 constexpr auto PULSES_PER_REVOLUTION_PARAM= "pulses_per_revolution";
-constexpr auto INIT_MOTOR_POWER_PARAM = "init_motor_power";
+constexpr auto INIT_MOTOR_POWER_PARAM = "initial_motor_power";
 
 constexpr auto DEVFILE_COUNTER_L = "/dev/rtcounter_l1";
 constexpr auto DEVFILE_COUNTER_R = "/dev/rtcounter_r1";

--- a/raspimouse/src/raspimouse_component.cpp
+++ b/raspimouse/src/raspimouse_component.cpp
@@ -233,8 +233,7 @@ CallbackReturn Raspimouse::on_activate(const rclcpp_lifecycle::State &)
   }
 
   // Set the motor on/off
-  const auto INIT_MOTOR_POWER = get_parameter(INIT_MOTOR_POWER_PARAM).get_value<bool>();
-  set_motor_power(INIT_MOTOR_POWER);
+  set_motor_power(get_parameter(INIT_MOTOR_POWER_PARAM).get_value<bool>());
 
   RCLCPP_INFO(this->get_logger(), "Raspimouse node activated");
   return CallbackReturn::SUCCESS;

--- a/raspimouse/src/raspimouse_component.cpp
+++ b/raspimouse/src/raspimouse_component.cpp
@@ -38,6 +38,7 @@ constexpr auto LIGHT_SENSORS_HZ_PARAM = "light_sensors_hz";
 constexpr auto WHEEL_DIAMETER_PARAM = "wheel_diameter";
 constexpr auto WHEEL_TREAD_PARAM = "wheel_tread";
 constexpr auto PULSES_PER_REVOLUTION_PARAM= "pulses_per_revolution";
+constexpr auto INIT_MOTOR_POWER_PARAM = "init_motor_power";
 
 constexpr auto DEVFILE_COUNTER_L = "/dev/rtcounter_l1";
 constexpr auto DEVFILE_COUNTER_R = "/dev/rtcounter_r1";
@@ -192,6 +193,7 @@ CallbackReturn Raspimouse::on_configure(const rclcpp_lifecycle::State &)
   declare_parameter(WHEEL_DIAMETER_PARAM, 0.048);
   declare_parameter(WHEEL_TREAD_PARAM, 0.0925);
   declare_parameter(PULSES_PER_REVOLUTION_PARAM, 400.0);
+  declare_parameter(INIT_MOTOR_POWER_PARAM, false);
 
   // Test if the pulse counters are available
   if (get_parameter(use_pulse_counters_param).get_value<bool>()) {
@@ -229,6 +231,9 @@ CallbackReturn Raspimouse::on_activate(const rclcpp_lifecycle::State &)
   if (get_parameter(use_light_sensors_param).get_value<bool>()) {
     light_sensors_timer_->reset();
   }
+
+  // Set the motor on/off
+  set_motor_power(INIT_MOTOR_POWER_PARAM);
 
   RCLCPP_INFO(this->get_logger(), "Raspimouse node activated");
   return CallbackReturn::SUCCESS;


### PR DESCRIPTION
<!-- プルリクエストのタイトルと以下の記述項目は、日本語で書いても良いです -->

# What does this implement/fix?
<!-- Explain your changes here. -->
<!-- このPRはどんな機能改善/修正ですか？ -->
`raspimouse`ノードをActivate状態にする時に、モータの内部スイッチをOn/Offに切り替えられるようにパラメータを追記した。

# Does this close any currently open issues?
<!-- このPRはオープンになっているissueをクローズしますか？ -->
No

# How has this been tested?
<!-- このPRはどのようにテストしましたか？ -->
ロボットはRaspberry Pi Mouse V3 + Raspberry Pi 4 Model Bを使用  
ロボットとパソコンは共に、Ubuntu 20.04とROS 2 Foxyを使用  
以下のコマンドを実行して、モータの内部スイッチの切り替えが行われているかを確認した  
```sh
# Terminal 1
ros2 run raspimouse raspimouse
# Terminal 2
ros2 lifecycle set raspimouse configure
ros2 lifecycle set raspimouse activate
```

# Any other comments?
<!-- その他コメントはありますか？ -->


# Checklists
<!-- PR作成時にチェックボックスにチェックを入れてください -->

- [x] <!-- コントリビューティングガイドラインを読みました--> I have read the CONTRIBUTING guidelines.
- [x] <!-- 同じ変更を要求するオープンなPRが無いことを確認しました --> I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same change.
