### PR TITLE
Add an instruction (issue #45) 

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,13 @@ $ colcon build --symlink-install
 $ source ~/ros2_ws/install/setup.bash
 ```
 
+If `colcon build --symlink-install` stops due to the lack of DRAM, please try
+```sh
+$ MAKEFLAGS=-j1 colcon build --symlink-install
+```
+instead.
+
+
 ## QuickStart
 
 ```sh


### PR DESCRIPTION
Since `colcon build` consumes 1GB DRAM, an instruction is added to README for the case where the command stops.

# 内容

[issue #45](https://github.com/rt-net/raspimouse2/issues/45) について、READMEに反映しました。

# テスト環境

Ubuntu 22.04 on ThinkPad X1で追加した説明にあるコマンドの動作を確認。
（週明けにラズパイ3B+でも試します。）


# Checklists
<!-- PR作成時にチェックボックスにチェックを入れてください -->

- [x ] <!-- コントリビューティングガイドラインを読みました--> I have read the CONTRIBUTING guidelines.
    <!-- リポジトリのガイドラインがない場合は、rt-net organaizationのガイドラインが適用されます -->
    - If there is no guideline in the repository, [rt-net organization's guideline](https://github.com/rt-net/.github/blob/master/CONTRIBUTING.md) applies.
- [ x] <!-- 同じ変更を要求するオープンなPRが無いことを確認しました --> I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same change.
